### PR TITLE
Use the combination of ID and size as the cache key.

### DIFF
--- a/_plugins/flickr_photo.rb
+++ b/_plugins/flickr_photo.rb
@@ -114,7 +114,7 @@ module Jekyll
     end
 
     def photo_key
-        "#{@photo[:id]}"
+        "#{@photo[:id]}-#{@photo[:size]}"      
     end
 
   end


### PR DESCRIPTION
This way you can use multiple sizes of the same image in different
places, and also experiment with different image sizes in --watch mode,
without the first cached size superseding all subsequently-requested sizes.
